### PR TITLE
WP-263 - White space between image and keywords

### DIFF
--- a/css/frontend/oer-curriculum-style.css
+++ b/css/frontend/oer-curriculum-style.css
@@ -51,10 +51,9 @@ body.single-oer-curriculum {
 .oercurr-tc-authors-list {
     font-weight: 600;
     font-size: 18px !important;
-    margin:5px 0;
+    margin:6px 0 5px 0;
     line-height: 24px;
     position:relative;
-    min-height: 40px;
 }
 .oercurr-tc-authors-list.padded-right {padding-right: 55px;}
 .oercurr-tc-details-description {
@@ -128,6 +127,9 @@ body.single-oer-curriculum {
     padding-right: 55px;
     float: left;
     width: 100%;
+}
+.oercurr-tc-keywords.padded-right.extend{
+    padding-right:0px;
 }
 .tc-sensitive-material-section i {
     color: #ED4141;
@@ -786,6 +788,11 @@ h4.oercurr-tc-field-heading span.oer_curriculum_related_fields, h4.tc-related-cu
 .tc-related-curriculum-details ul.tc-related-curriculum-list li a:focus { text-decoration: underline; }
 .oercurr-author-label, .oercurr-tc-label, .oercurr-tc-label-heading { margin-right:10px; font-size:14px; /*color:#4F4F4F;*/ font-weight:bold; text-transform: uppercase; }
 .oercurr-tc-author a { font-size:14px; }
+.oercurr-tc-authors-list .oercurr-author-label, 
+.oercurr-tc-authors-list .oercurr-tc-author {
+    line-height: 38px;
+    margin-right:0px;
+}
 .oercurr-tc-standards-list, .tc-related-curriculum-list, .oercurr-tc-subject-areas-list, .oercurr-tc-objectives-list { padding-left:0; margin-top: 0px; margin-bottom: 0px; padding-bottom:15px;}
 .oercurr-tc-standards-list li, .oercurr-tc-subject-areas-list li, .oercurr-tc-objectives-list li { list-style:none; font-size:14px; }
 .oercurr-tc-standards-list li a, .oercurr-tc-subject-areas-list li a { text-decoration: none; }

--- a/templates/single-oer-curriculum.php
+++ b/templates/single-oer-curriculum.php
@@ -457,10 +457,12 @@
                   </div>
               </div>
               <div class="col-xl-4 col-lg-5 col-md-5 col-sm-12 featured-image padding-right-0">
+                  <?php $keywordsWrapperClassname = 'extend' ?>
                   <?php the_post_thumbnail('inquiry-set-featured'); ?>
                   <?php $_feat_info_padding = ($oer_curriculum_download_copy_document && $download_copy_enabled)? 'padded-right' : ''; ?>
                   <div class="oercurr-tc-authors-list <?php echo esc_html($_feat_info_padding) ?>">
-                  <?php if (($author_set && $author_enabled) || !$author_set) { ?>
+                  <?php 
+                  if (($author_set && $author_enabled) || !$author_set) { ?>
                       <?php
                       $author_display = false;
                       foreach($authors as $author){
@@ -471,7 +473,7 @@
                       }
                       if ($author_display){
                           ?>
-                           <span class="oercurr-author-label"><?php echo esc_html(oercurr_get_field_label('oer_curriculum_authors')); ?></span>
+                           <span class="oercurr-author-label"><?php echo esc_html(oercurr_get_field_label('oer_curriculum_authors')); ?>:</span>
                           <?php 
                           $aIndex = 0;
                           
@@ -488,10 +490,15 @@
                                   
                               $aIndex++;
                           }
-                      } 
+                      }else{
+                        $keywordsWrapperClassname = '';
+                      }
                       ?>
                       
-                  <?php } ?>
+                  <?php 
+                  }else{
+                      $keywordsWrapperClassname = '';
+                  } ?>
                   
                   <?php if ($oer_curriculum_download_copy_document && $download_copy_enabled): ?>
                   <div class="oercurr-tc-controls">
@@ -511,7 +518,7 @@
                   if(!empty($keywords))
                   {
                   ?>
-                  <div class="oercurr-tc-keywords <?php echo esc_attr($_feat_info_padding) ?>">
+                  <div class="oercurr-tc-keywords <?php echo esc_attr($_feat_info_padding).' '.$keywordsWrapperClassname ?>">
                       <div class="oer_curriculum_keywords_container tagcloud">
                       <?php
                           foreach($keywords as $keyword)


### PR DESCRIPTION
- removed mac height css for author section so that it automatically retracts to zero height when empty, then the keywords section moves up.
- Added conditional class to keywords section to add padding to keywords section when author is not provided, that way, the keybords will not overlap the download button.