### PR TITLE
WP-264 - Excessive bottom margin on Sensitive Material icon

### DIFF
--- a/css/frontend/oer-curriculum-style.css
+++ b/css/frontend/oer-curriculum-style.css
@@ -327,7 +327,7 @@ span.selected-standard-pill:last-child {
     color: #ED4141;
     font-size: 20px !important;
 }
-.sensitive-source p { margin:0px; }
+.sensitive-source p { margin:0px !important; }
 .custom-bg-dark {
     background: #283d47 !important;
 }


### PR DESCRIPTION
- Add an !important rule in the existing bottom margin CSS.  This is necessary as Avada theme is overriding it and the same scenario may be possible in other themes also.