### PR TITLE
WP-249 - Curriculum description core/image and core/paragraph text wr…

### DIFF
--- a/css/backend/oer-curriculum-style.css
+++ b/css/backend/oer-curriculum-style.css
@@ -289,6 +289,7 @@ li.oer_sbstndard div ul li {
 .post-type-oer-curriculum .components-base-control__field {position: relative;}
 .post-type-oer-curriculum  span.components-checkbox-control__input-container {position: absolute;top: 0px;}
 .post-type-oer-curriculum  label.components-checkbox-control__label {padding-left: 25px;}
+.post-type-oer-curriculum .wp-block {clear: both;}
 
 .oer_curriculum_left_column.float {
     position: relative;

--- a/css/frontend/oer-curriculum-style.css
+++ b/css/frontend/oer-curriculum-style.css
@@ -63,7 +63,7 @@ body.single-oer-curriculum {
     font-size: 14px;
     line-height:18px;
 }
-.oercurr-tc-details-description p { color:#333 !important; font-size:14px; line-height:18px; margin:0px; }
+.oercurr-tc-details-description p { color:#333 !important; font-size:14px; line-height:18px; margin:0px;clear:left;}
 .oercurr-tc-details-standards-list { padding:20px 0; }
 .oercurr-tc-details-standards-list .oercurr-tc-details-standard {
     display: inline-block;


### PR DESCRIPTION
…apping issue

- Set a clear property to control the flow of paragraph next to floated elements.
- While debugging, I found an issue with the WordPress core image block wherein in block-editor it allows text to wrap while is doesn't at front end.  the only fix we can do is to align the editor with front-end.